### PR TITLE
#1 #78 장바구니 식품 추가 대표 아이콘 설정

### DIFF
--- a/src/main/java/com/example/icebutler_server/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/example/icebutler_server/cart/service/CartServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.icebutler_server.cart.dto.cart.response.CartResponse;
 import com.example.icebutler_server.cart.entity.cart.Cart;
 import com.example.icebutler_server.cart.entity.cart.CartFood;
 import com.example.icebutler_server.cart.repository.cart.CartFoodRepository;
+import com.example.icebutler_server.food.dto.assembler.FoodAssembler;
 import com.example.icebutler_server.food.entity.Food;
 import com.example.icebutler_server.food.entity.FoodCategory;
 import com.example.icebutler_server.food.repository.FoodRepository;
@@ -39,6 +40,7 @@ public class CartServiceImpl implements CartService {
     private final FridgeRepository fridgeRepository;
     private final CartFoodAssembler cartFoodAssembler;
     private final FridgeUserRepository fridgeUserRepository;
+    private final FoodAssembler foodAssembler;
 
 
     @Override
@@ -75,7 +77,7 @@ public class CartServiceImpl implements CartService {
         List<Food> foodRequests = new ArrayList<>();
         for(AddFoodRequest foodRequest : request.getFoodRequests()) {
             Food food = this.foodRepository.findByFoodNameAndFoodCategory(foodRequest.getFoodName(), FoodCategory.getFoodCategoryByName(foodRequest.getFoodCategory()));
-            if(food == null) food = this.foodRepository.save(new Food(foodRequest.getFoodName(), FoodCategory.getFoodCategoryByName(foodRequest.getFoodCategory())));
+            if(food == null) food = this.foodRepository.save(foodAssembler.toEntity(foodRequest));
             foodRequests.add(food);
         }
 

--- a/src/main/java/com/example/icebutler_server/cart/service/MultiCartServiceImpl.java
+++ b/src/main/java/com/example/icebutler_server/cart/service/MultiCartServiceImpl.java
@@ -10,6 +10,7 @@ import com.example.icebutler_server.cart.entity.multiCart.MultiCartFood;
 import com.example.icebutler_server.cart.exception.CartNotFoundException;
 import com.example.icebutler_server.cart.repository.multiCart.MultiCartFoodRepository;
 import com.example.icebutler_server.cart.repository.multiCart.MultiCartRepository;
+import com.example.icebutler_server.food.dto.assembler.FoodAssembler;
 import com.example.icebutler_server.food.entity.FoodCategory;
 import com.example.icebutler_server.food.entity.Food;
 import com.example.icebutler_server.food.repository.FoodRepository;
@@ -43,6 +44,7 @@ public class MultiCartServiceImpl implements CartService {
     private final MultiCartRepository multiCartRepository;
     private final FoodRepository foodRepository;
     private final MultiCartFoodAssembler multiCartFoodAssembler;
+    private final FoodAssembler foodAssembler;
 
     @Override
     public ResponseCustom<?> getFoodsFromCart(Long fridgeIdx, Long userIdx) {
@@ -76,7 +78,7 @@ public class MultiCartServiceImpl implements CartService {
         List<Food> foodRequests = new ArrayList<>();
         for(AddFoodRequest foodRequest : request.getFoodRequests()) {
             Food food = this.foodRepository.findByFoodNameAndFoodCategory(foodRequest.getFoodName(), FoodCategory.getFoodCategoryByName(foodRequest.getFoodCategory()));
-            if(food == null) food = this.foodRepository.save(new Food(foodRequest.getFoodName(), FoodCategory.getFoodCategoryByName(foodRequest.getFoodCategory())));
+            if(food == null) food = this.foodRepository.save(foodAssembler.toEntity(foodRequest));
             foodRequests.add(food);
         }
 

--- a/src/main/java/com/example/icebutler_server/food/dto/assembler/FoodAssembler.java
+++ b/src/main/java/com/example/icebutler_server/food/dto/assembler/FoodAssembler.java
@@ -1,19 +1,19 @@
 package com.example.icebutler_server.food.dto.assembler;
 
+import com.example.icebutler_server.cart.dto.cart.request.AddFoodRequest;
 import com.example.icebutler_server.food.dto.response.FoodRes;
 import com.example.icebutler_server.food.entity.Food;
 import com.example.icebutler_server.food.entity.FoodCategory;
 import com.example.icebutler_server.fridge.dto.fridge.request.FridgeFoodReq;
+import com.example.icebutler_server.global.util.Constant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import static com.example.icebutler_server.global.util.Constant.Food.ICON_EXTENSION;
 
 @Component
 @RequiredArgsConstructor
 public class FoodAssembler {
-
-//  public Food toEntity(FoodReq foodReq) {
-//    return Food.builder()
-//  }
 
   public Food toEntity(FridgeFoodReq fridgeFoodReq){
     return Food.builder()
@@ -29,6 +29,14 @@ public class FoodAssembler {
             .foodName(food.getFoodName())
             .foodCategory(food.getFoodCategory().getName())
             .foodIconName(food.getFoodIconName())
+            .build();
+  }
+
+  public Food toEntity(AddFoodRequest request) {
+    return Food.builder()
+            .foodName(request.getFoodName())
+            .foodIconName(request.getFoodCategory()+ ICON_EXTENSION)
+            .foodCategory(FoodCategory.getFoodCategoryByName(request.getFoodCategory()))
             .build();
   }
 }

--- a/src/main/java/com/example/icebutler_server/food/entity/Food.java
+++ b/src/main/java/com/example/icebutler_server/food/entity/Food.java
@@ -32,10 +32,5 @@ public class Food {
         this.foodCategory = foodCategory;
     }
 
-    @Builder
-    public Food(String foodName, FoodCategory foodCategory) {
-        this.foodName = foodName;
-        this.foodCategory = foodCategory;
-    }
 }
 

--- a/src/main/java/com/example/icebutler_server/global/util/Constant.java
+++ b/src/main/java/com/example/icebutler_server/global/util/Constant.java
@@ -4,4 +4,7 @@ public final class Constant {
   public static final String FRIDGE = "fridge";
   public static final String MULTI_FRIDGE = "multi";
   public static final String COMMA = ",";
+  public static class Food {
+    public static final String ICON_EXTENSION = ".png";
+  }
 }


### PR DESCRIPTION
## 💬 기타 사항
- 식품 카테고리별 대표 아이콘들 S3에 업로드 해놨습니다 (카테고리이름한글.png)
- 없는 식품 추가될 때마다 해당 카테고리 대표 아이콘으로 저장되도록 수정했습니다
