### PR TITLE
#201 유통기한 알림 저장 type 변경

### DIFF
--- a/src/main/java/com/example/icebutler_server/alarm/service/NotificationServiceImpl.java
+++ b/src/main/java/com/example/icebutler_server/alarm/service/NotificationServiceImpl.java
@@ -61,7 +61,7 @@ public class NotificationServiceImpl implements NotificationService {
             FcmMessage message = FcmMessage.makeMessage(user.getFcmToken(), fridgeName, messageBody);
             Response response = sendMessage(objectMapper.writeValueAsString(message));
             System.out.println(response.body().string()); // TODO 프론트와 테스트 확인 후 출력문 삭제
-            this.notificationRepository.save(this.notificationAssembler.toEntity(Constant.PushNotification.IMMINENT_EXPIRATION, messageBody, user));
+            this.notificationRepository.save(this.notificationAssembler.toEntity(fridgeName, messageBody, user));
         }
     }
 

--- a/src/main/java/com/example/icebutler_server/global/util/Constant.java
+++ b/src/main/java/com/example/icebutler_server/global/util/Constant.java
@@ -17,7 +17,6 @@ public final class Constant {
   }
 
   public static class PushNotification{
-    public static final String FRIDGE = "냉장고";
-    public static final String IMMINENT_EXPIRATION = "유통기한";
+    public static final String FRIDGE = "";
   }
 }


### PR DESCRIPTION
## 💬 기타 사항
- db 저장 값 수정
- 냉장고 초대/삭제 -> type: 냉장고
- 냉장고 유통기한 -> type: [냉장고 이름]
<hr>

- 가정용/공용 냉장고의 이름이 냉장고인 경우에는 초대/삭제인지 냉장고 유통기한인지 판단이 가지 않기 때문에
- type 저장 시
- 냉장고 유통기한인 경우에는 냉장고 이름을 저장하고
- 냉장고 초대/삭제인 경우에는 "" 를 넘겨주기로 프론트와 상의햇씀니당

- 그냥 머지할게요😎
