### PR TITLE
#195 관리자 식품 수정 레시피 서버 데이터 동기화 구현

### DIFF
--- a/src/main/java/com/example/icebutler_server/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/example/icebutler_server/admin/service/AdminServiceImpl.java
@@ -121,6 +121,7 @@ public class AdminServiceImpl implements AdminService {
             adminAssembler.validateFoodName(checkFood, request.getFoodName());
         }
         foodRepository.save(adminAssembler.toUpdateFoodInfo(food, request));
+        recipeServerEventPublisher.updateFood(food);
     }
 
     @Override

--- a/src/main/java/com/example/icebutler_server/global/feign/feignClient/RecipeServerClient.java
+++ b/src/main/java/com/example/icebutler_server/global/feign/feignClient/RecipeServerClient.java
@@ -29,6 +29,6 @@ public interface RecipeServerClient {
     @DeleteMapping("/foods")
     void deleteFood(@RequestBody FoodReq foodReq);
 
-    @PatchMapping("/foods")
+    @PostMapping("/foods")
     void updateFood(@RequestBody FoodReq foodReq);
 }

--- a/src/main/java/com/example/icebutler_server/global/feign/feignClient/RecipeServerClient.java
+++ b/src/main/java/com/example/icebutler_server/global/feign/feignClient/RecipeServerClient.java
@@ -28,4 +28,7 @@ public interface RecipeServerClient {
 
     @DeleteMapping("/foods")
     void deleteFood(@RequestBody FoodReq foodReq);
+
+    @PatchMapping("/foods")
+    void updateFood(@RequestBody FoodReq foodReq);
 }

--- a/src/main/java/com/example/icebutler_server/global/feign/handler/RecipeServerEventHandler.java
+++ b/src/main/java/com/example/icebutler_server/global/feign/handler/RecipeServerEventHandler.java
@@ -11,4 +11,6 @@ public interface RecipeServerEventHandler {
     void deleteUser(UserEvent userEvent);
 
     void deleteFood(FoodEvent foodEvent);
+
+    void updateFood(FoodEvent foodEvent);
 }

--- a/src/main/java/com/example/icebutler_server/global/feign/handler/RecipeServerEventHandlerImpl.java
+++ b/src/main/java/com/example/icebutler_server/global/feign/handler/RecipeServerEventHandlerImpl.java
@@ -51,4 +51,15 @@ public class RecipeServerEventHandlerImpl implements RecipeServerEventHandler{
     public void deleteFood(FoodEvent foodEvent) {
         recipeServerClient.deleteFood(foodEvent.toDto());
     }
+
+    @Async
+    @EventListener
+    @Override
+    public void updateFood(FoodEvent foodEvent) {
+        try {
+            recipeServerClient.updateFood(foodEvent.toDto());
+        } catch (FeignException e) {
+            log.error(e.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/example/icebutler_server/global/feign/publisher/RecipeServerEventPublisher.java
+++ b/src/main/java/com/example/icebutler_server/global/feign/publisher/RecipeServerEventPublisher.java
@@ -4,11 +4,13 @@ import com.example.icebutler_server.food.entity.Food;
 import com.example.icebutler_server.user.entity.User;
 
 public interface RecipeServerEventPublisher {
-    void addUser(User user);
+  void addUser(User user);
 
-    void changeUserProfile(User user);
+  void changeUserProfile(User user);
 
-    void deleteUser(User user);
+  void deleteUser(User user);
 
-    void deleteFood(Food food);
+  void deleteFood(Food food);
+
+  void updateFood(Food food);
 }

--- a/src/main/java/com/example/icebutler_server/global/feign/publisher/RecipeServerEventPublisherImpl.java
+++ b/src/main/java/com/example/icebutler_server/global/feign/publisher/RecipeServerEventPublisherImpl.java
@@ -34,5 +34,10 @@ public class RecipeServerEventPublisherImpl implements RecipeServerEventPublishe
         publisher.publishEvent(FoodEvent.toEvent(food));
     }
 
+    @Override
+    public void updateFood(Food food) {
+        publisher.publishEvent(FoodEvent.toEvent(food));
+    }
+
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,8 +69,7 @@ jwt:
 
 server:
   recipe:
-#    url: https://za8hqdiis4.execute-api.ap-northeast-2.amazonaws.com/dev/dev-ice-bulter-recipe
-    url: http://localhost:8070
+    url: https://za8hqdiis4.execute-api.ap-northeast-2.amazonaws.com/dev/dev-ice-bulter-recipe
 
 apple:
   production:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,7 +69,8 @@ jwt:
 
 server:
   recipe:
-    url: https://za8hqdiis4.execute-api.ap-northeast-2.amazonaws.com/dev/dev-ice-bulter-recipe
+#    url: https://za8hqdiis4.execute-api.ap-northeast-2.amazonaws.com/dev/dev-ice-bulter-recipe
+    url: http://localhost:8070
 
 apple:
   production:


### PR DESCRIPTION
## 💬 기타 사항
- 메인서버에서 레시피 서버로 업데이트 요청 보낼 때 PatchMapping을 사용하면 레시피 서버에서 DeleteMapping이 반응하고, 요청에 없는 isEnable을 0으로 만드는 문제가 있습니다. PostMapping으로 요청시 정상작동합니다.